### PR TITLE
intro 패널 진행 안내 + stepper 홈/1/2 + 사건 핀 인물 색 N등분

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -154,7 +154,7 @@ static const _palette = <Color>[
 
 | 화면 | 파일 | 역할 |
 |------|------|------|
-| StoryHomeScreen | `screens/story_home_screen.dart` | 메인 화면 (인물+지도+타임라인+프로필) |
+| StoryHomeScreen | `screens/story_home_screen.dart` | 메인 화면 (인물+지도+타임라인+프로필). 시트 헤더는 **단일 toggle 동그라미** — 연한 초록 pill (`_activeColor.withAlpha(0.16)` + 0.45 border) 안에 ▲/▼ 한 개. 옛 indicator bar 는 제거 (드래그로 오해되던 문제). 우측 stepper 는 **홈·1·2·?** 라벨 — step 1 dot 은 `Icons.home_rounded` 로 "intro 화면 복귀" 가 직관적. 시트는 화면 맨 아래(`bottom: 0`) 까지 차지하고 height 를 `sheetHeight + bottomInset` 으로 키운다 — 각 panel(`_buildHomeIntroPanel` / `_buildRegionPanel` / `StorySelectionPanel`) 의 자체 양피지 deco 가 nav bar 영역까지 자연스럽게 이어지고, 컨텐츠는 panel Column 마지막의 `SizedBox(bottomInset)` 로 nav bar 위에 위치 (gesture-only 단말은 bottomInset=0 → 기존 동작). 모드별 hint 는 `MapHintOverlay` 가 표시, dismiss state 는 `_mapHintDismissed`. 인물 모드(`_SelectionMode.character`) 진입 시 `StoryMapPanel.suppressRegionLabels=true` 로 가나안·시내 광야·애굽 등 검정 캡슐 라벨을 숨겨 인물 path 점선이 가려지지 않게 한다. |
 | ~~LoginScreen~~ | ~~`screens/login_screen.dart`~~ | 삭제됨 — InlineLoginPromptCard로 대체 |
 | ProfileNotesScreen | `screens/profile_notes_screen.dart` | 노트 목록 |
 | ProfileNoteEditorScreen | `screens/profile_note_editor_screen.dart` | 노트 편집 |
@@ -175,9 +175,9 @@ static const _palette = <Color>[
 
 | 위젯 | 파일 | 역할 |
 |------|------|------|
-| StoryMapPanel | `widgets/story_map_panel.dart` | flutter_map 지도. 일반 사건 핀 외에 ① `activeLandmarks` (선택된 시대의 랜드마크만 — 이모지 + 이름) ② `activeEraBoundaries` — 선택된 시대의 폴리곤 리스트를 받아 `PolygonLayer` 로 반투명 채움 + 외곽선 렌더 (한 시대가 분리 영역을 가지면 여러 폴리곤이 함께 그려짐). region polygon 시각은 `EraPolygonGlowLayer` 로 분리, hit-test 만 투명 `PolygonLayer<Landmark>` 가 담당. |
-| EraPolygonGlowLayer | `widgets/map/era_polygon_glow_layer.dart` | region polygon 시각 전용 layer. **Ancient atlas discovery 양식** — 4-layer (outer glow / parchment radial fill / ink border halo+main / discovery particles) + Catmull-Rom spline 곡선화. era 색 기반, 선택 시 펄스 강조 + edge 따라 빛 입자 twinkle. fantasy atlas / fog-of-war reveal 톤. flutter_map 의 `PolygonLayer` 가 단색 fill 만 지원하므로 별도 `CustomPainter` 레이어. 클릭 hit-test 는 동일 좌표의 투명 PolygonLayer 가 담당. |
-| StorySelectionPanel | `widgets/story_selection_panel.dart` | 인물 선택 + 이벤트 목록 통합 |
+| StoryMapPanel | `widgets/story_map_panel.dart` | flutter_map 지도. 일반 사건 핀 외에 ① `activeLandmarks` (선택된 시대의 랜드마크만 — 이모지 + 이름) ② `activeEraBoundaries` — 선택된 시대의 폴리곤 리스트를 받아 `PolygonLayer` 로 반투명 채움 + 외곽선 렌더 (한 시대가 분리 영역을 가지면 여러 폴리곤이 함께 그려짐). region polygon 시각은 `EraPolygonGlowLayer` 로 분리, hit-test 만 투명 `PolygonLayer<Landmark>` 가 담당. **`onMapInteraction`** 콜백 — `_isUserGestureSource` 로 사용자 제스처(드래그·핀치·스크롤·탭) 만 식별해 부모의 hint overlay dismiss 트리거. **`suppressRegionLabels`** prop — 인물 모드에서 검정 캡슐 region 라벨이 path 점선을 가리지 않도록 부모가 토글. 인물 모드 step 3 의 번호 핀(`_NumberedEventPin`) 은 사건에 포함된 선택 인물 색을 모아 `_MultiColorCirclePainter` 로 위→아래 균등 N 등분 띠를 그려 인물별 식별. selected 핀은 character color 위에 노란 outer border 로 강조. |
+| EraPolygonGlowLayer | `widgets/map/era_polygon_glow_layer.dart` | region polygon 시각 전용 layer. **Ancient atlas discovery 양식** — 4-layer (outer glow / parchment radial fill / ink border halo+main / discovery particles) + Catmull-Rom spline 곡선화. era 색 기반, 선택 시 펄스 강조 + edge 따라 빛 입자 twinkle. fantasy atlas / fog-of-war reveal 톤. flutter_map 의 `PolygonLayer` 가 단색 fill 만 지원하므로 별도 `CustomPainter` 레이어. 클릭 hit-test 는 동일 좌표의 투명 PolygonLayer 가 담당. **`EraPolygonEntry.pickerHighlight`** — region picker 단계의 후보 폴리곤이면 outer glow / fill alpha 가 0.06~0.08 부스트되어 "여기를 누르세요" 인상을 강화 (선택 폴리곤이 항상 더 또렷하도록 isSelected 가 우선). |
+| StorySelectionPanel | `widgets/story_selection_panel.dart` | 인물 선택 + 이벤트 목록 통합. **헤더(`headerOverride`) 는 sticky** — `Column [header, Expanded(CustomScrollView)]` 구조로 사건 카드 스크롤 시 헤더(toggle + stepper) 가 함께 위로 사라지지 않는다. step 3 사건 카드(`EventTimelineRow`) 는 `committedSelectedCharacterCodes` + `colorForCommittedCharacter` 를 그대로 forwarding 해 카드 안 인물 pill 이 지도 path 색과 매칭된다. |
 | CharacterPanel | `widgets/character_panel.dart` | 인물 카드 (아바타, 설명) |
 | ~~StoryListPanel~~ | ~~`widgets/story_list_panel.dart`~~ | 삭제됨 — StorySelectionPanel이 통합 |
 | ParchmentDialog | `widgets/parchment_dialog.dart` | 이야기 상세 모달 |
@@ -207,6 +207,8 @@ static const _palette = <Color>[
 | PulseHighlight | `widgets/pulse_highlight.dart` | `active` 인 동안 자식 외곽에 1.4s 사이클로 0→1→0 박동하는 골드 glow 를 그리는 래퍼. EventDetailPage 의 "다음 이야기" 카드에 부착해 다음 이동 동선을 시각적으로 유도. |
 | AvatarProgressRing | `widgets/avatar_progress_ring.dart` | 아바타 둘레에 초록 원형 progress 호를 그리는 래퍼 (12시 방향 시계방향, 항상 초록). 옵션 `name` 을 주면 아바타 내부 하단에 솔리드 다크 pill 라벨을 오버레이해 외부 텍스트 라인을 제거. ProfileTabPage 인물 진행도 행에서 LinearProgressIndicator 대체로 사용. |
 | EraPickRows | `widgets/v2/era_pick_rows.dart` | 시대 선택 칩 — 구약/신약 두 줄. HomeIntroPanel + ProfileTabPage 의 "장소로 시작" 탭 공유. `eraIconFor(code)` 도 export. |
+| HomeIntroPanel | `widgets/v2/home_intro_panel.dart` | 첫 화면 "오늘은 성경 어디를 여행해볼까요?" 패널. 두 단계: ① **여행할 시대** (구약/신약 칩, 단일 선택) ② **어떻게 볼까요?** (장소에서 시작 / 인물과 걷기). 시대를 고른 뒤에는 ① 영역(헤더+칩) 이 `AnimatedOpacity` 0.55 로 흐려지고 ② 헤더는 `ink800` + 굵은 글씨로 차별화되어 다음 행동을 유도. 제목/하단 안내 문구는 `FittedBox.scaleDown` + `maxLines:1` 로 좁은 폰에서도 1줄 보장. |
+| MapHintOverlay | `widgets/v2/map_hint_overlay.dart` | 지도 위 흐릿한 검정 패널 안내 문구. 모드별로 다른 메시지: region picker 단계 = "노란 지역을 눌러…", character step 2 = "인물을 골라 「다음」…". 사용자가 지도 제스처/region 선택/character 다음 한 번만 하면 dismiss. `IgnorePointer` 로 감싸 폴리곤·핀 클릭은 그대로 통과. dismiss flag 는 `StoryHomeScreen._mapHintDismissed`. |
 | ProfileMiniMap | `widgets/profile/profile_mini_map.dart` | 프로필 "장소로 시작" 탭의 미니 맵. 선택된 시대의 region 폴리곤을 진행률로 알파 채움(검정→시대컬러), 100% region 은 황금 깃발 마커. 상단에 "정복: X / N" 칩. point-in-polygon 으로 사건↔region 매핑. |
 | BibleReaderPage | `widgets/bible_reader_page.dart` | 성경 리더 페이지 (자체 상태 관리, 저장 구절 토글) |
 | WeeklyTabPage | `widgets/weekly_tab_page.dart` | 금주 인물 학습 탭 (자체 데이터 로딩 + 상태) |

--- a/lib/screens/story_home_screen.dart
+++ b/lib/screens/story_home_screen.dart
@@ -33,6 +33,7 @@ import '../widgets/story_home_styles.dart';
 import '../widgets/story_map_panel.dart';
 import '../widgets/story_selection_panel.dart';
 import '../widgets/v2/home_intro_panel.dart';
+import '../widgets/v2/map_hint_overlay.dart';
 import '../widgets/v2/region_event_list.dart';
 import '../widgets/v2/region_pick_panel.dart';
 import 'notification_history_screen.dart';
@@ -89,6 +90,14 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
   /// (step 2 인물 토글과 같은 패턴). "다음" 버튼은 단순히 선택 패널을 접는
   /// 역할만 한다.
   Set<String> _draftDisplayedEventIds = <String>{};
+
+  /// 지도 위 안내 오버레이([MapHintOverlay])를 사용자가 한 번이라도 dismiss
+  /// 했는지. 새 단계 진입 (`_handlePickMode` / `_handleStepperTap`) 시 false 로
+  /// reset 되어 안내가 다시 보이고, 사용자가 지도를 만지거나 region/인물을
+  /// 선택하면 true 가 되어 사라진다. step·mode 자체가 "안내가 필요 없는" 상태
+  /// (예: region 선택 완료, character step 3) 면 _currentMapHint() 가 null 을
+  /// 반환해 이 플래그와 무관하게 hint 가 안 뜬다.
+  bool _mapHintDismissed = false;
 
   @override
   void initState() {
@@ -347,6 +356,44 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
     ref.read(storyControllerProvider.notifier).setSelectedCharacters(next);
   }
 
+  /// 현재 단계/모드에 어울리는 지도 안내 문구. null 이면 hint 미표시.
+  /// 사용자가 dismiss (지도 제스처/region 선택 등) 했으면 null.
+  ({String message, IconData icon})? _currentMapHint() {
+    if (_mapHintDismissed) return null;
+    if (_mode == _SelectionMode.region) {
+      final state = ref.read(storyControllerProvider);
+      if (state.selectedLandmarkId == null) {
+        return (
+          message: '노란 지역을 눌러 그곳의 사건을 보세요.\n손가락 동작으로 지도를 확대·축소할 수 있어요.',
+          icon: Icons.touch_app_rounded,
+        );
+      }
+      return null;
+    }
+    if (_mode == _SelectionMode.character && _selectionStep == 2) {
+      return (
+        message: '아래 패널에서 인물을 한 명 이상 고른 뒤\n좌측 상단의 「다음」 버튼을 눌러주세요.',
+        icon: Icons.people_alt_rounded,
+      );
+    }
+    return null;
+  }
+
+  /// 사용자가 지도를 만지면(드래그/줌/탭 등) hint dismiss. _mapHintDismissed=true
+  /// 로 다음 단계 진입 전까지 hint 가 다시 안 뜬다.
+  void _handleMapInteraction() {
+    if (_mapHintDismissed) return;
+    setState(() {
+      _mapHintDismissed = true;
+    });
+  }
+
+  /// 새 단계로 들어갔거나 mode 가 바뀌었을 때 hint 를 다시 보여 줄 수 있도록
+  /// dismiss flag 를 reset. setState 안에서 호출해야 build 에 반영된다.
+  void _resetMapHint() {
+    _mapHintDismissed = false;
+  }
+
   void _animateSelectionPanelToStage(StorySelectionPanelStage stage) {
     final state = ref.read(storyControllerProvider);
     final maxExtent = _isInRevealMode(state)
@@ -479,6 +526,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
         _mode = null;
         _selectionStep = 1;
         _draftSelectedCharacterCodes = const <String>{};
+        // intro 화면은 자체 안내가 충분하므로 hint overlay 는 dismiss.
+        _mapHintDismissed = true;
       });
       _animateSelectionPanelToStage(StorySelectionPanelStage.expanded);
       return;
@@ -492,6 +541,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
       setState(() {
         _selectionStep = 2;
         _draftSelectedCharacterCodes = const <String>{};
+        // 새 단계 시작 — hint overlay 다시 보여줌.
+        _resetMapHint();
       });
       // region 모드는 사용자가 지도에서 폴리곤/핀을 직접 누르는 단계 — 패널은
       // 최소화해 지도가 보이게. character 모드는 인물 카드를 골라야 하니 expand.
@@ -569,6 +620,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
       _selectionSheetExtent = _selectionSheetCollapsedSize;
       _awaitingRevealComplete = true;
       _revealInstantly = false;
+      // region 선택 완료 — hint overlay 사라짐.
+      _mapHintDismissed = true;
     });
     // 사건들이 분포한 영역에 fit + 줌인. region 폴리곤 fit 보다 사건 자체에
     // 포커스가 맞아 자세히 보임.
@@ -599,6 +652,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
       _selectionSheetExtent = _selectionSheetCollapsedSize;
       _awaitingRevealComplete = true;
       _revealInstantly = false;
+      // character step 3 진입 — 인물 선택 안내 hint 사라짐.
+      _mapHintDismissed = true;
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _mapPanelController.focusEvents(zoomBoost: 1.0);
@@ -1628,6 +1683,10 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
 
     final mapZoom = state.selectedEraIds.isEmpty ? 6.0 : selectedEra?.mapZoom;
     final topInset = MediaQuery.of(context).padding.top;
+    // Android 3-button nav bar / iOS home indicator 등 system gesture bar 가
+    // 차지하는 픽셀. gesture-only / 풀스크린 모드면 0. 이 값만큼 시트를 위로
+    // 띄워야 패널 하단이 nav bar 에 가려지지 않는다 (사용자 보고).
+    final bottomInset = MediaQuery.of(context).padding.bottom;
     const outerMargin = 20.0;
     // Toolbar (38) + 8 gap + chip bar (28) + 6 gap = 80. 약간 여유 두어 88.
     final mapCalloutTopObscuredPixels = topInset + 88;
@@ -1664,12 +1723,17 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
               initialCenter: mapCenter,
               initialZoom: mapZoom,
               topObscuredPixels: mapCalloutTopObscuredPixels,
-              bottomObscuredFraction: _selectionSheetExtent > 0
-                  ? _selectionSheetExtent
-                  : _sheetSizeForStage(
-                      MediaQuery.sizeOf(context),
-                      _selectionPanelStage,
-                    ),
+              // 시트 비율 + nav bar 비율 합산. nav bar 영역까지 obscured 로 처리해
+              // 콜아웃이 그 위에 그려지지 않게 한다 (panel 을 nav bar 위로 띄운
+              // 만큼 panel + nav bar 가 같이 가린다).
+              bottomObscuredFraction:
+                  (_selectionSheetExtent > 0
+                      ? _selectionSheetExtent
+                      : _sheetSizeForStage(
+                          MediaQuery.sizeOf(context),
+                          _selectionPanelStage,
+                        )) +
+                  (bottomInset / MediaQuery.sizeOf(context).height),
               decorate: false,
               activeLandmarks: _activeLandmarksForEra(state),
               activeEraBoundaries: state.selectedEraIds.isEmpty
@@ -1757,6 +1821,13 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
                 }
                 return code;
               },
+              // 사용자가 지도와 상호작용하면(드래그/줌/탭 등) hint overlay 를
+              // dismiss. region/character 단계 진입 시 _resetMapHint() 가
+              // 다시 보여줌.
+              onMapInteraction: _handleMapInteraction,
+              // 인물 모드에서는 region 검정 캡슐 라벨(가나안·시내 광야·애굽 등)
+              // 이 인물 path 점선을 가리는 문제가 있어 라벨을 숨긴다.
+              suppressRegionLabels: _mode == _SelectionMode.character,
             ),
           ),
           // 카테고리 필터 칩 — 시대가 선택돼야 의미가 있으므로 그때만 표시.
@@ -1796,6 +1867,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
               final sheetHeight =
                   constraints.maxHeight *
                   _sheetSizeForStage(viewportSize, _selectionPanelStage);
+              // 모드별 지도 안내 문구. null 이면 hint overlay 미표시.
+              final mapHint = _currentMapHint();
 
               return Stack(
                 children: [
@@ -1805,16 +1878,22 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
                   Positioned(
                     left: sheetHorizontalMargin,
                     right: sheetHorizontalMargin,
+                    // 시트는 화면 맨 아래까지 차지하고 height 를 sheetHeight +
+                    // bottomInset 으로 키운다 — panel 자체의 양피지 deco 가 그
+                    // height 에 맞게 늘어나 nav bar 영역까지 자연스럽게 양피지가
+                    // 이어진다. 각 panel 은 자체적으로 bottomInset 만큼 마지막
+                    // spacer 를 두어 컨텐츠를 nav bar 위로 띄운다.
+                    // (gesture-only 단말은 bottomInset=0 이라 기존과 동일한 동작.)
                     bottom: 0,
                     child: AnimatedContainer(
                       key: const ValueKey<String>('selection-sheet'),
                       duration: const Duration(milliseconds: 280),
                       curve: Curves.easeOutCubic,
-                      height: sheetHeight,
+                      height: sheetHeight + bottomInset,
                       child: _mode == _SelectionMode.region
-                          ? _buildRegionPanel(state)
+                          ? _buildRegionPanel(state, bottomInset)
                           : (_mode == null && _selectionStep == 1)
-                          ? _buildHomeIntroPanel(state)
+                          ? _buildHomeIntroPanel(state, bottomInset)
                           : StorySelectionPanel(
                               scrollController: _selectionPanelScrollController,
                               step: _selectionStep,
@@ -1960,6 +2039,23 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
                       ),
                     ),
                   ),
+                  // 지도 위 모드별 안내 오버레이. 사용자가 무엇을 해야 할지
+                  // 모를 때 가운데 흐리게 떠 있다가, 지도 제스처/region 선택/
+                  // 인물 「다음」 등 한 번의 행동으로 dismiss. IgnorePointer 로
+                  // 감싸 hint 가 떠 있어도 폴리곤·핀 클릭은 그대로 가능.
+                  if (mapHint != null)
+                    Positioned(
+                      top: topInset + 96,
+                      left: 0,
+                      right: 0,
+                      bottom: bottomInset + sheetHeight + 16,
+                      child: IgnorePointer(
+                        child: MapHintOverlay(
+                          message: mapHint.message,
+                          icon: mapHint.icon,
+                        ),
+                      ),
+                    ),
                 ],
               );
             },
@@ -2028,8 +2124,14 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
     );
   }
 
-  /// 시트 헤더 — ▲▼ 토글 + 가운데 인디케이터 + 우측 stepper(1-2-3-?).
-  /// 우측 상단 stepper Positioned 는 제거하고 여기에 통합해 화면 공간 확보.
+  /// 시트 헤더 — 가운데 핸들(인디케이터 + 단일 toggle 화살표) + 우측
+  /// stepper(홈·1·2·?). 좌측은 stepper 와 균형을 맞춘 빈 공간 (또는
+  /// 인물 모드 step 1 의 "N명 다음" 핀).
+  ///
+  /// 옛 ▲▼ 두 IconButton 은 stepper 와 시각적으로 충돌해 사용자가 ▲ 를
+  /// 인지하지 못하는 문제가 있었다 (panel half stage 도 실질적으로 expanded 와
+  /// 동일 사이즈라 두 버튼이 redundant). 핸들 영역 전체가 하나의 InkWell —
+  /// 탭하면 collapsed ↔ expanded 토글.
   Widget _panelStageHandle() {
     final stage = _selectionPanelStage;
     final state = ref.read(storyControllerProvider);
@@ -2039,13 +2141,17 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
         _mode == _SelectionMode.character &&
         _selectionStep == 2 &&
         draftCharacters.isNotEmpty;
+    // stepper 의 estimated width (3 dots × 20 + 2 separators × 10 + helpButton
+    // 20 + paddings 12 + 6 ≈ 128). 좌측 SizedBox 도 같은 width 로 맞춰
+    // 가운데 핸들 영역이 정확히 화면 중앙에 오게 한다.
+    const headerSideSlot = 128.0;
+    final isExpanded = stage == StorySelectionPanelStage.expanded;
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
       child: Row(
         children: [
-          // 좌측 — "N명 다음" 핀 (조건부) 또는 stepper 균형용 빈 공간.
           SizedBox(
-            width: 110,
+            width: headerSideSlot,
             child: showCharacterNext
                 ? Align(
                     alignment: Alignment.centerLeft,
@@ -2057,69 +2163,65 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
                 : null,
           ),
           Expanded(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                IconButton(
-                  iconSize: 18,
-                  visualDensity: VisualDensity.compact,
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 28,
-                    minHeight: 28,
+            child: Center(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () => _animateSelectionPanelToStage(
+                    isExpanded
+                        ? StorySelectionPanelStage.collapsed
+                        : StorySelectionPanelStage.expanded,
                   ),
-                  tooltip: '아래로',
-                  onPressed: stage == StorySelectionPanelStage.collapsed
-                      ? null
-                      : () => _animateSelectionPanelToStage(
-                          stage == StorySelectionPanelStage.expanded
-                              ? StorySelectionPanelStage.half
-                              : StorySelectionPanelStage.collapsed,
+                  child: Tooltip(
+                    message: isExpanded ? '아래로 접기' : '위로 펼치기',
+                    child: Container(
+                      width: 48,
+                      height: 30,
+                      decoration: BoxDecoration(
+                        // stepper 의 활성 초록(_activeColor 0xFF2E8B57) 의 옅은
+                        // tint 로 panel toggle 임을 색으로 시그널링.
+                        color: const Color(0xFF2E8B57).withValues(alpha: 0.16),
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(
+                          color: const Color(
+                            0xFF2E8B57,
+                          ).withValues(alpha: 0.45),
+                          width: 1,
                         ),
-                  icon: const Icon(Icons.keyboard_arrow_down),
-                ),
-                Container(
-                  width: 28,
-                  height: 3,
-                  margin: const EdgeInsets.symmetric(horizontal: 4),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF8C6743).withValues(alpha: 0.45),
-                    borderRadius: BorderRadius.circular(2),
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(
+                        isExpanded
+                            ? Icons.keyboard_arrow_down
+                            : Icons.keyboard_arrow_up,
+                        size: 22,
+                        color: const Color(0xFF2E8B57),
+                        semanticLabel: isExpanded ? '아래로 접기' : '위로 펼치기',
+                      ),
+                    ),
                   ),
                 ),
-                IconButton(
-                  iconSize: 18,
-                  visualDensity: VisualDensity.compact,
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(
-                    minWidth: 28,
-                    minHeight: 28,
-                  ),
-                  tooltip: '위로',
-                  onPressed: stage == StorySelectionPanelStage.expanded
-                      ? null
-                      : () => _animateSelectionPanelToStage(
-                          stage == StorySelectionPanelStage.collapsed
-                              ? StorySelectionPanelStage.half
-                              : StorySelectionPanelStage.expanded,
-                        ),
-                  icon: const Icon(Icons.keyboard_arrow_up),
-                ),
-              ],
+              ),
             ),
           ),
-          // 우측 stepper (1-2-3-?) — 기존 우측 상단에서 이동.
-          _SelectionStepper(
-            currentStep: _currentStepperIndex(),
-            mode: _mode,
-            onStepTap: _handleStepperTap,
+          SizedBox(
+            width: headerSideSlot,
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: _SelectionStepper(
+                currentStep: _currentStepperIndex(),
+                mode: _mode,
+                onStepTap: _handleStepperTap,
+              ),
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildHomeIntroPanel(StoryState state) {
+  Widget _buildHomeIntroPanel(StoryState state, double bottomInset) {
     return Container(
       decoration: _parchmentPanelDecoration(),
       clipBehavior: Clip.antiAlias,
@@ -2127,6 +2229,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
         children: [
           _panelStageHandle(),
           Expanded(child: _buildHomeIntroBody(state)),
+          // nav bar 영역에는 panel 양피지만 노출 — 컨텐츠는 그 위로 띄움.
+          if (bottomInset > 0) SizedBox(height: bottomInset),
         ],
       ),
     );
@@ -2162,6 +2266,7 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
       ctl.setSelectionMode(SelectionMode.region);
       setState(() {
         _mode = _SelectionMode.region;
+        _resetMapHint();
       });
       // 슬라이딩 패널을 collapsed 로 내려서 사용자가 지도에서 region 마커를
       // 직접 클릭해 선택할 수 있게 한다.
@@ -2188,6 +2293,7 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
     setState(() {
       _mode = _SelectionMode.character;
       _selectionStep = 2;
+      _resetMapHint();
     });
   }
 
@@ -2218,7 +2324,7 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
     _mapPanelController.focusRegion(allPoints);
   }
 
-  Widget _buildRegionPanel(StoryState state) {
+  Widget _buildRegionPanel(StoryState state, double bottomInset) {
     final eraCodes = state.eras
         .where((e) => state.selectedEraIds.contains(e.id))
         .map((e) => e.code)
@@ -2278,6 +2384,8 @@ class _StoryHomeScreenState extends ConsumerState<StoryHomeScreen> {
                     },
                   ),
           ),
+          // nav bar 영역에는 panel 양피지만 노출 — 컨텐츠는 그 위로 띄움.
+          if (bottomInset > 0) SizedBox(height: bottomInset),
         ],
       ),
     );
@@ -3343,10 +3451,27 @@ class _SelectionStepper extends StatelessWidget {
         children: [
           for (var i = 1; i <= 3; i++) ...[
             _StepDot(
-              number: i,
               color: _colorFor(i),
               enabled: i <= currentStep,
               onTap: () => onStepTap(i),
+              tooltip: i == 1 ? '홈으로 (시대·보는 방법 다시 선택)' : '${i - 1}단계',
+              // step 1 = "홈" (intro 화면 복귀), step 2/3 = "1"/"2".
+              // 사용자가 시대 선택 후 첫 화면으로 다시 가는 방법을 직관적으로
+              // 인지할 수 있도록 라벨 변경 (이전엔 "1"이라 헷갈렸음).
+              child: i == 1
+                  ? const Icon(
+                      Icons.home_rounded,
+                      size: 12,
+                      color: Colors.white,
+                    )
+                  : Text(
+                      '${i - 1}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 10.5,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
             ),
             if (i < 3)
               Container(
@@ -3366,20 +3491,22 @@ class _SelectionStepper extends StatelessWidget {
 
 class _StepDot extends StatelessWidget {
   const _StepDot({
-    required this.number,
+    required this.child,
     required this.color,
     required this.enabled,
     required this.onTap,
+    this.tooltip,
   });
 
-  final int number;
+  final Widget child;
   final Color color;
   final bool enabled;
   final VoidCallback onTap;
+  final String? tooltip;
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
+    final dot = MouseRegion(
       cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
       child: GestureDetector(
         onTap: enabled ? onTap : null,
@@ -3401,17 +3528,12 @@ class _StepDot extends StatelessWidget {
                 : null,
           ),
           alignment: Alignment.center,
-          child: Text(
-            '$number',
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 10.5,
-              fontWeight: FontWeight.w900,
-            ),
-          ),
+          child: child,
         ),
       ),
     );
+    if (tooltip == null) return dot;
+    return Tooltip(message: tooltip!, child: dot);
   }
 }
 
@@ -3535,16 +3657,28 @@ void _showStepperHelp(BuildContext context) {
                   margin: const EdgeInsets.only(bottom: 14),
                 ),
                 const _HelpStep(
-                  number: 1,
-                  title: '시대 + 보는 방법 선택',
+                  badge: Icon(
+                    Icons.home_rounded,
+                    color: Colors.white,
+                    size: 16,
+                  ),
+                  title: '홈 — 시대 + 보는 방법 선택',
                   body:
                       '먼저 여행할 시대를 한 가지 고르세요. 그 다음 「장소에서 시작」 또는 '
-                      '「인물과 걷기」 두 보는 방법 중 하나를 선택합니다.',
+                      '「인물과 걷기」 두 보는 방법 중 하나를 선택합니다. 언제든지 「홈」 '
+                      '동그라미를 눌러 이 화면으로 돌아올 수 있습니다.',
                 ),
                 const SizedBox(height: 12),
                 const _HelpStep(
-                  number: 2,
-                  title: '장소 또는 인물 선택',
+                  badge: Text(
+                    '1',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 14,
+                    ),
+                  ),
+                  title: '1단계 — 장소 또는 인물 선택',
                   body:
                       '「장소에서 시작」을 골랐다면 지도 위 폴리곤이나 핀을 눌러 한 지역을 '
                       '고르세요. 「인물과 걷기」를 골랐다면 등장 인물을 한 명 이상 고른 뒤 '
@@ -3552,8 +3686,15 @@ void _showStepperHelp(BuildContext context) {
                 ),
                 const SizedBox(height: 12),
                 const _HelpStep(
-                  number: 3,
-                  title: '사건 선택',
+                  badge: Text(
+                    '2',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 14,
+                    ),
+                  ),
+                  title: '2단계 — 사건 선택',
                   body:
                       '선택한 지역 또는 인물에 얽힌 사건들이 시간 순서대로 지도에 핀으로 '
                       '박힙니다. 사건 카드를 누르면 자세한 이야기 페이지로 이동합니다.',
@@ -3626,11 +3767,11 @@ void _showStepperHelp(BuildContext context) {
 
 class _HelpStep extends StatelessWidget {
   const _HelpStep({
-    required this.number,
+    required this.badge,
     required this.title,
     required this.body,
   });
-  final int number;
+  final Widget badge;
   final String title;
   final String body;
 
@@ -3647,14 +3788,7 @@ class _HelpStep extends StatelessWidget {
             shape: BoxShape.circle,
           ),
           alignment: Alignment.center,
-          child: Text(
-            '$number',
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.w900,
-              fontSize: 14,
-            ),
-          ),
+          child: badge,
         ),
         const SizedBox(width: 10),
         Expanded(

--- a/lib/widgets/event_timeline_row.dart
+++ b/lib/widgets/event_timeline_row.dart
@@ -26,11 +26,22 @@ class EventTimelineRow extends StatefulWidget {
     this.connectorWidth = 22,
     this.rowHeight,
     this.padding = const EdgeInsets.fromLTRB(14, 18, 14, 14),
+    this.highlightedCharacterCodes = const <String>{},
+    this.colorForHighlightedCharacter,
   });
 
   final List<StoryEvent> events;
   final List<Era> allEras;
   final Map<String, Character> charactersByCode;
+
+  /// 카드 안 인물 pill 중 강조해 앞쪽에 배치할 인물 코드. 인물 모드 step 3
+  /// 에서 사용자가 고른 인물 set 을 부모가 넘긴다. 비어 있으면 모든 pill
+  /// default 톤 + 원래 순서.
+  final Set<String> highlightedCharacterCodes;
+
+  /// highlighted 인물의 강조 색을 반환. 일반적으로 부모의 `colorForCharacter`
+  /// (지도 path 색) 을 그대로 넘긴다.
+  final Color Function(String characterCode)? colorForHighlightedCharacter;
 
   /// 현재 "현재 이야기" 라벨이 붙어야 하는 사건 id. null 이면 미강조.
   /// set 변경 시 자동 스크롤로 그 카드를 viewport 중앙에 배치.
@@ -189,6 +200,8 @@ class _EventTimelineRowState extends State<EventTimelineRow> {
             orderNumber: idx + 1,
             loader: _loader,
             onTap: () => widget.onTapEvent(event),
+            highlightedCharacterCodes: widget.highlightedCharacterCodes,
+            colorForHighlightedCharacter: widget.colorForHighlightedCharacter,
           ),
         );
       },

--- a/lib/widgets/map/era_polygon_glow_layer.dart
+++ b/lib/widgets/map/era_polygon_glow_layer.dart
@@ -15,6 +15,7 @@ class EraPolygonEntry {
     required this.eraColor,
     required this.isSelected,
     required this.pulseT,
+    this.pickerHighlight = false,
   });
 
   /// LatLng 정점들. ring 종결은 자동 — 마지막을 첫 정점으로 잇는다.
@@ -31,6 +32,11 @@ class EraPolygonEntry {
 
   /// 0..1 한 사이클 펄스 위상. glow/border 펄스 + particle 위상에 사용.
   final double pulseT;
+
+  /// region 선택 단계(`regionPickerMode`)의 후보 폴리곤인지. true 면 outer
+  /// glow / fill alpha 가 +0.06~0.08 부스트되어 "여기를 누르세요" 인상을 강화.
+  /// `isSelected` 가 우선되므로 선택된 폴리곤에는 영향 없음.
+  final bool pickerHighlight;
 }
 
 /// flutter_map 위에 ancient parchment atlas 톤으로 region polygon 을 그리는
@@ -111,30 +117,33 @@ class EraPolygonGlowLayer extends StatefulWidget {
   // "어두운 색의 깜빡거림" 으로 인식돼 양피지 톤과 충돌했음. entry.pulseT 인자는
   // 호환성 위해 EraPolygonEntry 에 남기되 더 이상 참조하지 않는다.
 
-  /// Outer glow alpha. 비선택 0.12, 선택 0.18 (옛 0.18/0.22~0.30 → 더 절제).
+  /// Outer glow alpha. 비선택 0.12, 선택 0.18, picker 후보 0.20 (사용자가
+  /// "노란 영역을 누르세요" 안내를 받을 때 시각적으로 더 또렷하게).
   static double outerGlowAlphaFor({required EraPolygonEntry entry}) {
-    return entry.isSelected ? 0.18 : 0.12;
+    if (entry.isSelected) return 0.18;
+    return entry.pickerHighlight ? 0.20 : 0.12;
   }
 
-  /// Outer glow blur sigma. 비선택 9, 선택 12 (옛 10/11~14 → 살짝 축소).
+  /// Outer glow blur sigma. 비선택 9, 선택 12, picker 후보 11.
   static double outerGlowSigmaFor({required EraPolygonEntry entry}) {
-    return entry.isSelected ? 12.0 : 9.0;
+    if (entry.isSelected) return 12.0;
+    return entry.pickerHighlight ? 11.0 : 9.0;
   }
 
   // ─────────────────── Parchment fill ────────────────────
 
-  /// Parchment fill 중앙 alpha. 비선택 0.50, 선택 0.62.
+  /// Parchment fill 중앙 alpha. 비선택 0.50, 선택 0.62, picker 후보 0.56.
   /// (white wash 위로 칠해지므로 베이스 비침 차단된 상태에서 의도된 톤이
   /// 또렷이 살아남는 알파. 펄스 제거로 안정적 표시.)
   static double fillCenterAlphaFor({required EraPolygonEntry entry}) {
-    return entry.isSelected ? 0.62 : 0.50;
+    if (entry.isSelected) return 0.62;
+    return entry.pickerHighlight ? 0.56 : 0.50;
   }
 
-  /// Parchment fill 가장자리 alpha. 비선택 0.36, 선택 0.48.
-  /// (가장자리까지 균일하게 톤이 살아남도록 boost. center↔edge 격차를 줄여
-  /// "안쪽만 진하고 가장자리 비는" 인상 회피.)
+  /// Parchment fill 가장자리 alpha. 비선택 0.36, 선택 0.48, picker 후보 0.42.
   static double fillEdgeAlphaFor({required EraPolygonEntry entry}) {
-    return entry.isSelected ? 0.48 : 0.36;
+    if (entry.isSelected) return 0.48;
+    return entry.pickerHighlight ? 0.42 : 0.36;
   }
 
   /// White wash 레이어 alpha — 양피지 베이스 중성화 강도.

--- a/lib/widgets/story_map_panel.dart
+++ b/lib/widgets/story_map_panel.dart
@@ -137,7 +137,20 @@ class StoryMapPanel extends StatefulWidget {
     this.eraCodeForId,
     this.eventCountByLandmarkId,
     this.regionPickerMode = false,
+    this.onMapInteraction,
+    this.suppressRegionLabels = false,
   });
+
+  /// 사용자가 지도와 상호작용 (drag/zoom/pan/탭) 했을 때 호출. 부모는 이를
+  /// 활용해 "지도를 움직여 보세요" 같은 hint overlay 를 dismiss 한다.
+  /// programmatic 카메라 이동(focusEvents 등) 은 제외 — `MapEventSource` 가
+  /// 사용자 제스처일 때만 호출된다.
+  final VoidCallback? onMapInteraction;
+
+  /// true 면 `_buildRegionLabels` 가 그리는 검정 캡슐 라벨(가나안·시내 광야·
+  /// 애굽 등) 을 숨긴다. 인물 모드에서 인물 path 점선이 그 라벨에 가려져
+  /// 잘 안 보이는 문제를 해결하기 위해 부모가 토글한다.
+  final bool suppressRegionLabels;
 
   /// true 일 때 step 2 (장소 선택) UI: 나라/region 핀 라벨 숨기고, 폴리곤 자체가
   /// 선택 가능한 큰 단위로 노출 (폴리곤 중앙에 region 이름 + 사건 개수 배지).
@@ -251,6 +264,22 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
 
   /// 줌 변경 디버그 로깅용 — 0.05 이상 변하면 콘솔 로그.
   double? _lastLoggedZoom;
+
+  /// flutter_map [MapEventSource] 중 사용자 제스처(드래그·핀치·스크롤·탭·키보드
+  /// 등) 인 경우 true. programmatic 카메라 이동 / fitCamera / size change 는
+  /// false. hint overlay dismiss 등 "사용자가 지도를 만졌다" 를 판정할 때 사용.
+  static bool _isUserGestureSource(MapEventSource s) {
+    switch (s) {
+      case MapEventSource.mapController:
+      case MapEventSource.fitCamera:
+      case MapEventSource.nonRotatedSizeChange:
+      case MapEventSource.interactiveFlagsChanged:
+      case MapEventSource.custom:
+        return false;
+      default:
+        return true;
+    }
+  }
 
   /// 시대 region 폴리곤 클릭 hit-test 용. flutter_map 8.x 의 hitNotifier API.
   /// Polygon 에 hitValue=Landmark 부여 → 사용자가 onTap 시 hitValue 로 어떤
@@ -547,12 +576,18 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
                   },
                   // 디버그 — 줌 변경 시 콘솔에 로깅 (0.05 이상 변할 때만).
                   // min/max 줌 튜닝용. release 시 제거.
+                  // 추가로, 사용자 제스처(드래그/멀티터치/스크롤휠/더블탭) 시
+                  // [onMapInteraction] 호출 — 부모의 hint overlay dismiss 트리거.
+                  // programmatic 이동(focusEvents 등 mapController source) 은 제외.
                   onMapEvent: (event) {
                     final z = event.camera.zoom;
                     final last = _lastLoggedZoom;
                     if (last == null || (z - last).abs() > 0.05) {
                       _lastLoggedZoom = z;
                       debugPrint('[Map] zoom: ${z.toStringAsFixed(2)}');
+                    }
+                    if (_isUserGestureSource(event.source)) {
+                      widget.onMapInteraction?.call();
                     }
                   },
                   onMapReady: () {
@@ -679,7 +714,7 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
                       ),
                     ),
                   PolylineLayer(polylines: polylines),
-                  if (!widget.regionPickerMode)
+                  if (!widget.regionPickerMode && !widget.suppressRegionLabels)
                     MarkerLayer(markers: _buildRegionLabels()),
                   // 폴리곤 중앙에 region 이름 + 사건 개수 라벨.
                   // step 2 (regionPickerMode): 모든 era region 라벨 표시 (갈색).
@@ -1233,6 +1268,10 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
           eraColor: _eraColorForRegion(lm),
           isSelected: lm.id == widget.selectedLandmarkId,
           pulseT: 0.0,
+          // region 선택 단계에서 후보 폴리곤 (선택되지 않은 것) 을 시각적으로
+          // 강화 — 사용자가 "여기를 누르세요" 안내와 함께 더 또렷하게 인식.
+          pickerHighlight:
+              widget.regionPickerMode && lm.id != widget.selectedLandmarkId,
         ),
       );
     }
@@ -1385,6 +1424,21 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
     int order,
     bool selected,
   ) {
+    // 인물 모드: 사건에 등장하는 인물 중 사용자가 고른 인물의 색을 모은다.
+    // 핀 동그라미를 N 색 가로 띠로 채워 "어느 인물 사건인지" 색으로 식별.
+    // - 1명: 단색 fill
+    // - 2명: 위/아래 반반
+    // - 3+명: 균등 N 등분
+    // 매칭이 없으면 (예: region 모드) 빈 리스트 → 기존 갈색 fill 폴백.
+    // event.characterCodes 의 원래 순서를 유지해 카드 안 pill 정렬과 일치.
+    final characterColors = <Color>[];
+    if (widget.selectedCharacterCodes.isNotEmpty) {
+      for (final code in event.characterCodes) {
+        if (widget.selectedCharacterCodes.contains(code)) {
+          characterColors.add(widget.colorForCharacter(code));
+        }
+      }
+    }
     return Marker(
       point: point,
       width: 22,
@@ -1403,7 +1457,11 @@ class _StoryMapPanelState extends State<StoryMapPanel> {
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () => widget.onSelectEvent(event.id),
-              child: _NumberedEventPin(number: order, isSelected: selected),
+              child: _NumberedEventPin(
+                number: order,
+                isSelected: selected,
+                characterColors: characterColors,
+              ),
             ),
           );
         },
@@ -2600,13 +2658,25 @@ class _MarkerWithSelection {
 /// 사건 핀 — 동그라미 + 안에 큰 순서 번호. 핀 모양/장소 라벨 모두 제거.
 /// 선택 시 더 큰 사이즈 + 노란 색 (현재 이야기). 미선택은 갈색 동그라미.
 class _NumberedEventPin extends StatelessWidget {
-  const _NumberedEventPin({required this.number, required this.isSelected});
+  const _NumberedEventPin({
+    required this.number,
+    required this.isSelected,
+    this.characterColors = const <Color>[],
+  });
 
   final int number;
   final bool isSelected;
 
+  /// 사건에 포함된 "사용자가 고른 인물" 의 색 리스트. 비어 있으면 기존
+  /// 단색 fill (selected → 노랑, else → 갈색). 1+ 면 [_MultiColorCirclePainter]
+  /// 가 핀 동그라미를 N 등분 가로 띠로 채워 인물별 식별을 시각화한다.
+  /// selected 일 때도 character color 를 우선 표시하고 노란 outer border 와
+  /// 두꺼운 stroke 로 "현재 이야기" 강조.
+  final List<Color> characterColors;
+
   @override
   Widget build(BuildContext context) {
+    final hasColors = characterColors.isNotEmpty;
     final fillColor = isSelected
         ? const Color(0xFFE8A33D) // 노랑 (현재 이야기)
         : const Color(0xFF6B4A2A); // 갈색 (일반 사건)
@@ -2615,7 +2685,8 @@ class _NumberedEventPin extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        color: fillColor,
+        // hasColors 면 fill 은 painter 가 담당 → 컨테이너 배경 투명.
+        color: hasColors ? null : fillColor,
         shape: BoxShape.circle,
         border: Border.all(
           color: isSelected ? const Color(0xFFFFE9B0) : Colors.white,
@@ -2630,16 +2701,66 @@ class _NumberedEventPin extends StatelessWidget {
         ],
       ),
       alignment: Alignment.center,
-      child: Text(
-        '$number',
-        style: TextStyle(
-          fontSize: isSelected ? 9 : 8,
-          fontWeight: FontWeight.w900,
-          color: Colors.white,
-          height: 1.0,
-        ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (hasColors)
+            ClipOval(
+              child: SizedBox(
+                width: size,
+                height: size,
+                child: CustomPaint(
+                  painter: _MultiColorCirclePainter(colors: characterColors),
+                ),
+              ),
+            ),
+          Text(
+            '$number',
+            style: TextStyle(
+              fontSize: isSelected ? 9 : 8,
+              fontWeight: FontWeight.w900,
+              color: Colors.white,
+              height: 1.0,
+              shadows: hasColors
+                  ? const [Shadow(color: Color(0xCC000000), blurRadius: 1.6)]
+                  : null,
+            ),
+          ),
+        ],
       ),
     );
+  }
+}
+
+/// `_NumberedEventPin` 안의 가로 띠 N 등분 painter — 인물 모드에서 사건에
+/// 포함된 선택 인물의 색을 위에서 아래로 같은 높이로 칠한다. ClipOval 안에
+/// 그려져 정사각형 painter 가 원형으로 잘린다. N=1 이면 단색 채움.
+class _MultiColorCirclePainter extends CustomPainter {
+  const _MultiColorCirclePainter({required this.colors});
+
+  final List<Color> colors;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (colors.isEmpty) return;
+    final n = colors.length;
+    final stripeH = size.height / n;
+    for (var i = 0; i < n; i++) {
+      final paint = Paint()..color = colors[i];
+      // 마지막 띠는 1px 여유로 fill — rounding 으로 hairline 안 생기게.
+      final top = i * stripeH;
+      final bottom = i == n - 1 ? size.height : (i + 1) * stripeH;
+      canvas.drawRect(Rect.fromLTRB(0, top, size.width, bottom), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MultiColorCirclePainter old) {
+    if (old.colors.length != colors.length) return true;
+    for (var i = 0; i < colors.length; i++) {
+      if (old.colors[i] != colors[i]) return true;
+    }
+    return false;
   }
 }
 

--- a/lib/widgets/story_selection_panel.dart
+++ b/lib/widgets/story_selection_panel.dart
@@ -164,50 +164,55 @@ class _StorySelectionPanelState extends State<StorySelectionPanel> {
                     onStepDown: widget.onStepDown,
                   )
                 else
-                  Stack(
+                  // 헤더(toggle + stepper) 는 Column 으로 분리해 sticky.
+                  // 옛 구조(headerOverride 도 SliverToBoxAdapter) 에서는
+                  // 사건 카드 스크롤 시 헤더가 함께 위로 사라져 카드가 잘린
+                  // 인상을 주었다. 이제 헤더 아래까지만 컨텐츠가 스크롤된다.
+                  Column(
                     children: [
-                      CustomScrollView(
-                        controller: widget.scrollController,
-                        physics: const ClampingScrollPhysics(),
-                        slivers: [
-                          if (widget.headerOverride != null)
-                            SliverToBoxAdapter(child: widget.headerOverride!)
-                          else ...[
-                            const SliverToBoxAdapter(
-                              child: SizedBox(height: 10),
+                      if (widget.headerOverride != null)
+                        widget.headerOverride!
+                      else ...[
+                        const SizedBox(height: 10),
+                        _PanelTopRow(
+                          stage: widget.panelStage,
+                          onStepUp: widget.onStepUp,
+                          onStepDown: widget.onStepDown,
+                          // step 2 + 선택 있을 때만 우측 작은 '다음' 핀.
+                          showCharacterNext:
+                              widget.step == 2 &&
+                              widget.draftSelectedCharacterCodes.isNotEmpty,
+                          characterCount:
+                              widget.draftSelectedCharacterCodes.length,
+                          onNextFromCharacters: widget.onNextFromCharacters,
+                        ),
+                      ],
+                      Expanded(
+                        child: Stack(
+                          children: [
+                            CustomScrollView(
+                              controller: widget.scrollController,
+                              physics: const ClampingScrollPhysics(),
+                              slivers: [
+                                // v3 — step 1/2/3 칩 + '다음' 버튼 헤더 제거.
+                                // 우측 상단 _SelectionStepper 가 단계 이동 담당.
+                                const SliverToBoxAdapter(
+                                  child: SizedBox(height: 6),
+                                ),
+                                ..._buildBodySlivers(),
+                                SliverToBoxAdapter(
+                                  child: SizedBox(height: bottomInset + 18),
+                                ),
+                              ],
                             ),
-                            SliverToBoxAdapter(
-                              child: _PanelTopRow(
-                                stage: widget.panelStage,
-                                onStepUp: widget.onStepUp,
-                                onStepDown: widget.onStepDown,
-                                // step 2 + 선택 있을 때만 우측 작은 '다음' 핀.
-                                showCharacterNext:
-                                    widget.step == 2 &&
-                                    widget
-                                        .draftSelectedCharacterCodes
-                                        .isNotEmpty,
-                                characterCount:
-                                    widget.draftSelectedCharacterCodes.length,
-                                onNextFromCharacters:
-                                    widget.onNextFromCharacters,
-                              ),
+                            const Positioned(
+                              left: 0,
+                              right: 0,
+                              bottom: 0,
+                              child: IgnorePointer(child: _BottomFadeHint()),
                             ),
                           ],
-                          // v3 — step 1/2/3 칩 + '다음' 버튼 헤더 제거.
-                          // 우측 상단 _SelectionStepper 가 단계 이동 담당.
-                          const SliverToBoxAdapter(child: SizedBox(height: 6)),
-                          ..._buildBodySlivers(),
-                          SliverToBoxAdapter(
-                            child: SizedBox(height: bottomInset + 18),
-                          ),
-                        ],
-                      ),
-                      const Positioned(
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        child: IgnorePointer(child: _BottomFadeHint()),
+                        ),
                       ),
                     ],
                   ),
@@ -374,6 +379,11 @@ class _StorySelectionPanelState extends State<StorySelectionPanel> {
           onTapEvent: (event) => widget.onOpenEventDetail?.call(event),
           // SliverToBoxAdapter 안 — fixed height 필요.
           rowHeight: 248,
+          // 카드 안 인물 pill: 사용자가 인물 모드에서 고른 인물을 가장 앞쪽에
+          // 배치하고 지도 path 색과 동일한 톤으로 강조 — 모든 등장 인물이
+          // 똑같이 보여서 헷갈리던 문제 해결.
+          highlightedCharacterCodes: widget.committedSelectedCharacterCodes,
+          colorForHighlightedCharacter: widget.colorForCommittedCharacter,
         ),
       ),
     ];

--- a/lib/widgets/v2/home_intro_panel.dart
+++ b/lib/widgets/v2/home_intro_panel.dart
@@ -34,6 +34,9 @@ class HomeIntroPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final canPickMode = selectedEraId != null;
+    // 시대를 골랐으면 1번 영역(헤더+칩)은 흐리게 처리해 시선을 2번으로 유도.
+    // 칩 자체는 클릭 가능 — 사용자가 시대를 다른 것으로 바꿀 수 있게 IgnorePointer X.
+    final eraStepOpacity = canPickMode ? 0.55 : 1.0;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
@@ -41,37 +44,55 @@ class HomeIntroPanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Center(
-            child: Text(
-              '🌿  오늘은 성경 어디를 여행해볼까요?  🌿',
-              style: AppTextStyles.h3.copyWith(
-                color: AppColors.ink800,
-                fontWeight: FontWeight.w800,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                '🌿  오늘은 성경 어디를 여행해볼까요?  🌿',
+                maxLines: 1,
+                style: AppTextStyles.h3.copyWith(
+                  color: AppColors.ink800,
+                  fontWeight: FontWeight.w800,
+                ),
               ),
             ),
           ),
           const SizedBox(height: 16),
-          const _StepHeader(
-            number: 1,
-            title: '여행할 시대를 골라보세요',
-            enabled: true,
-            iconData: Icons.schedule_outlined,
-          ),
-          const SizedBox(height: 8),
-          EraPickRows(
-            eras: eras,
-            selectedEraId: selectedEraId,
-            onSelectEra: onSelectEra,
+          AnimatedOpacity(
+            opacity: eraStepOpacity,
+            duration: const Duration(milliseconds: 240),
+            curve: Curves.easeOut,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _StepHeader(
+                  number: 1,
+                  title: '여행할 시대를 골라보세요',
+                  enabled: true,
+                  done: canPickMode,
+                  iconData: Icons.schedule_outlined,
+                ),
+                const SizedBox(height: 8),
+                EraPickRows(
+                  eras: eras,
+                  selectedEraId: selectedEraId,
+                  onSelectEra: onSelectEra,
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 18),
           _StepHeader(
             number: 2,
             title: '어떻게 볼까요?',
             enabled: canPickMode,
+            highlighted: canPickMode,
             iconData: Icons.explore_outlined,
           ),
           const SizedBox(height: 8),
-          Opacity(
+          AnimatedOpacity(
             opacity: canPickMode ? 1.0 : 0.45,
+            duration: const Duration(milliseconds: 240),
+            curve: Curves.easeOut,
             child: IgnorePointer(
               ignoring: !canPickMode,
               child: Row(
@@ -101,9 +122,13 @@ class HomeIntroPanel extends StatelessWidget {
           ),
           const SizedBox(height: 14),
           Center(
-            child: Text(
-              '💡  시대를 켜면 지도 위에 같은 색으로 영역이 표시됩니다.',
-              style: AppTextStyles.hint.copyWith(color: AppColors.ink450),
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                '💡  시대를 켜면 지도 위에 같은 색으로 영역이 표시됩니다.',
+                maxLines: 1,
+                style: AppTextStyles.hint.copyWith(color: AppColors.ink450),
+              ),
             ),
           ),
         ],
@@ -118,23 +143,49 @@ class _StepHeader extends StatelessWidget {
     required this.title,
     required this.enabled,
     required this.iconData,
+    this.done = false,
+    this.highlighted = false,
   });
   final int number;
   final String title;
   final bool enabled;
   final IconData iconData;
 
+  /// 이 단계가 이미 완료된 상태(다음 단계로 넘어가야 함). 완료 표식(✓) 노출.
+  final bool done;
+
+  /// 사용자가 지금 눌러야 할 단계임을 강조. 색을 ink800 + 굵은 글씨로 차별화.
+  final bool highlighted;
+
   @override
   Widget build(BuildContext context) {
-    final color = enabled ? AppColors.ink450 : AppColors.ink150;
+    final Color color;
+    if (!enabled) {
+      color = AppColors.ink150;
+    } else if (highlighted) {
+      color = AppColors.ink800;
+    } else {
+      color = AppColors.ink450;
+    }
     return Row(
       children: [
         Icon(iconData, size: 16, color: color),
         const SizedBox(width: 6),
         Text(
           '$number. $title',
-          style: AppTextStyles.sectionTitle.copyWith(color: color),
+          style: AppTextStyles.sectionTitle.copyWith(
+            color: color,
+            fontWeight: highlighted ? FontWeight.w800 : null,
+          ),
         ),
+        if (done) ...[
+          const SizedBox(width: 6),
+          Icon(
+            Icons.check_circle,
+            size: 14,
+            color: color.withValues(alpha: 0.8),
+          ),
+        ],
       ],
     );
   }

--- a/lib/widgets/v2/map_hint_overlay.dart
+++ b/lib/widgets/v2/map_hint_overlay.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+/// 지도 위에 떠 있는 흐릿한 안내 문구. 사용자가 무엇을 해야 할지 모를 때
+/// 화면 가운데에 잠시 보여주고, 사용자가 한 번 행동(폴리곤 탭·줌·인물 선택
+/// 후 다음 등)하면 부모가 visible=false 로 dismiss 한다.
+///
+/// 입력 차단을 안 하므로 hint 가 떠 있어도 그 아래의 폴리곤·핀은 정상 클릭
+/// 가능 (부모에서 IgnorePointer 로 감싸 사용).
+class MapHintOverlay extends StatelessWidget {
+  const MapHintOverlay({super.key, required this.message, this.icon});
+
+  final String message;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 220),
+        margin: const EdgeInsets.symmetric(horizontal: 32),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+        constraints: const BoxConstraints(maxWidth: 360),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.55),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(
+            color: Colors.white.withValues(alpha: 0.22),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.30),
+              blurRadius: 14,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, color: Colors.white.withValues(alpha: 0.92), size: 26),
+              const SizedBox(height: 8),
+            ],
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.95),
+                fontSize: 13.5,
+                fontWeight: FontWeight.w600,
+                height: 1.45,
+                shadows: [
+                  Shadow(
+                    color: Colors.black.withValues(alpha: 0.55),
+                    blurRadius: 4,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/v2/region_event_list.dart
+++ b/lib/widgets/v2/region_event_list.dart
@@ -126,6 +126,8 @@ class StoryEventThumbCard extends StatelessWidget {
     required this.onTap,
     this.completed = false,
     this.orderNumber,
+    this.highlightedCharacterCodes = const <String>{},
+    this.colorForHighlightedCharacter,
   });
   final StoryEvent event;
   final Era? era;
@@ -135,6 +137,33 @@ class StoryEventThumbCard extends StatelessWidget {
   final int? orderNumber;
   final SceneAssetLoader loader;
   final VoidCallback onTap;
+
+  /// 사용자가 명시적으로 고른 인물 코드(예: 인물 모드 step 3 의 선택된 인물).
+  /// 이 인물들의 pill 은 [colorForHighlightedCharacter] 색으로 강조되고
+  /// pills 가로 스크롤에서 가장 앞쪽에 배치된다. 비어 있으면 모든 pill 이
+  /// default 파랑 톤 + 원래 순서.
+  final Set<String> highlightedCharacterCodes;
+
+  /// highlighted 인물의 강조 색을 반환. null 이면 인물 코드와 무관하게
+  /// 모두 default 파랑. 일반적으로 부모가 지도 path 색과 동일한 함수를 넘겨
+  /// "지도 점선 색 = 카드 라벨 색" 시각 일관성을 만든다.
+  final Color Function(String characterCode)? colorForHighlightedCharacter;
+
+  /// pill 정렬 순서: highlighted 인물 먼저(원래 순서 유지), 그 다음 나머지
+  /// (원래 순서 유지). highlighted set 이 비어 있으면 원래 순서 그대로.
+  List<String> _orderedCharacterCodes() {
+    if (highlightedCharacterCodes.isEmpty) return event.characterCodes;
+    final highlighted = <String>[];
+    final rest = <String>[];
+    for (final code in event.characterCodes) {
+      if (highlightedCharacterCodes.contains(code)) {
+        highlighted.add(code);
+      } else {
+        rest.add(code);
+      }
+    }
+    return [...highlighted, ...rest];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -269,37 +298,49 @@ class StoryEventThumbCard extends StatelessWidget {
                   const SizedBox(height: 6),
                   // 인물 pill — 한 줄에 가로 스크롤. 인물 라벨이 2줄로 wrap
                   // 되어 카드가 overflow 되는 것을 방지. ShaderMask 우측
-                  // 페이드로 "더 있음" 힌트.
+                  // 페이드로 "더 있음" 힌트. highlighted 인물(부모가 명시적으로
+                  // 고른 인물) 은 가장 앞쪽 + 자기 색으로 강조.
                   if (event.characterCodes.isNotEmpty)
-                    SizedBox(
-                      height: 18,
-                      child: ShaderMask(
-                        shaderCallback: (bounds) => const LinearGradient(
-                          begin: Alignment.centerLeft,
-                          end: Alignment.centerRight,
-                          stops: [0.0, 0.85, 1.0],
-                          colors: [
-                            Colors.white,
-                            Colors.white,
-                            Color(0x00FFFFFF),
-                          ],
-                        ).createShader(bounds),
-                        blendMode: BlendMode.dstIn,
-                        child: ListView.separated(
-                          scrollDirection: Axis.horizontal,
-                          padding: EdgeInsets.zero,
-                          physics: const ClampingScrollPhysics(),
-                          itemCount: event.characterCodes.length,
-                          separatorBuilder: (_, __) => const SizedBox(width: 3),
-                          itemBuilder: (_, i) {
-                            final code = event.characterCodes[i];
-                            return _CharPillAvatar(
-                              character: charactersByCode[code],
-                              name: charactersByCode[code]?.name ?? code,
-                            );
-                          },
-                        ),
-                      ),
+                    Builder(
+                      builder: (_) {
+                        final ordered = _orderedCharacterCodes();
+                        return SizedBox(
+                          height: 18,
+                          child: ShaderMask(
+                            shaderCallback: (bounds) => const LinearGradient(
+                              begin: Alignment.centerLeft,
+                              end: Alignment.centerRight,
+                              stops: [0.0, 0.85, 1.0],
+                              colors: [
+                                Colors.white,
+                                Colors.white,
+                                Color(0x00FFFFFF),
+                              ],
+                            ).createShader(bounds),
+                            blendMode: BlendMode.dstIn,
+                            child: ListView.separated(
+                              scrollDirection: Axis.horizontal,
+                              padding: EdgeInsets.zero,
+                              physics: const ClampingScrollPhysics(),
+                              itemCount: ordered.length,
+                              separatorBuilder: (_, __) =>
+                                  const SizedBox(width: 3),
+                              itemBuilder: (_, i) {
+                                final code = ordered[i];
+                                final isHighlighted = highlightedCharacterCodes
+                                    .contains(code);
+                                return _CharPillAvatar(
+                                  character: charactersByCode[code],
+                                  name: charactersByCode[code]?.name ?? code,
+                                  accentColor: isHighlighted
+                                      ? colorForHighlightedCharacter?.call(code)
+                                      : null,
+                                );
+                              },
+                            ),
+                          ),
+                        );
+                      },
                     ),
                 ],
               ),
@@ -410,16 +451,35 @@ class _CardThumbnail extends StatelessWidget {
 }
 
 class _CharPillAvatar extends StatelessWidget {
-  const _CharPillAvatar({required this.character, required this.name});
+  const _CharPillAvatar({
+    required this.character,
+    required this.name,
+    this.accentColor,
+  });
   final Character? character;
   final String name;
+
+  /// 부모가 명시적으로 강조하라고 지정한 색. null 이면 default 파랑 톤
+  /// (0xFF3F8FB6) 으로 표시. 사용자가 인물 모드에서 고른 인물의 pill 에
+  /// 지도 path 점선 색과 동일한 색을 넘기면 시각적 매칭이 된다.
+  final Color? accentColor;
+
   @override
   Widget build(BuildContext context) {
+    const defaultColor = Color(0xFF3F8FB6);
+    const defaultText = Color(0xFF2A6F92);
+    final color = accentColor ?? defaultColor;
+    final textColor = accentColor != null
+        ? Color.alphaBlend(color.withValues(alpha: 0.85), Colors.black)
+        : defaultText;
     return Container(
       padding: const EdgeInsets.fromLTRB(2, 2, 6, 2),
       decoration: BoxDecoration(
-        color: const Color(0xFF3F8FB6).withValues(alpha: 0.18),
+        color: color.withValues(alpha: 0.20),
         borderRadius: BorderRadius.circular(10),
+        border: accentColor != null
+            ? Border.all(color: color.withValues(alpha: 0.55), width: 0.8)
+            : null,
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -436,18 +496,15 @@ class _CharPillAvatar extends StatelessWidget {
             Container(
               width: 14,
               height: 14,
-              decoration: const BoxDecoration(
-                shape: BoxShape.circle,
-                color: Color(0xFF3F8FB6),
-              ),
+              decoration: BoxDecoration(shape: BoxShape.circle, color: color),
             ),
           const SizedBox(width: 3),
           Text(
             name,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 9.5,
               fontWeight: FontWeight.w800,
-              color: Color(0xFF2A6F92),
+              color: textColor,
             ),
           ),
         ],

--- a/test/widgets/map/era_polygon_glow_layer_test.dart
+++ b/test/widgets/map/era_polygon_glow_layer_test.dart
@@ -11,12 +11,14 @@ EraPolygonEntry _entry({
   required bool selected,
   double pulse = 0.0,
   Color color = const Color(0xFF6F8F58),
+  bool pickerHighlight = false,
 }) {
   return EraPolygonEntry(
     polygon: [const LatLng(0, 0), const LatLng(0, 1), const LatLng(1, 0)],
     eraColor: color,
     isSelected: selected,
     pulseT: pulse,
+    pickerHighlight: pickerHighlight,
   );
 }
 
@@ -54,6 +56,38 @@ void main() {
           entry: _entry(selected: true, pulse: 0.25),
         ),
         12.0,
+      );
+    });
+
+    test('pickerHighlight: 비선택 후보가 일반(0.12) 보다 부스트(>0.12), 선택(0.18) '
+        '보다는 약함 — "여기를 누르세요" 안내 강화하되 선택 폴리곤이 더 또렷', () {
+      final base = EraPolygonGlowLayer.outerGlowAlphaFor(
+        entry: _entry(selected: false),
+      );
+      final picker = EraPolygonGlowLayer.outerGlowAlphaFor(
+        entry: _entry(selected: false, pickerHighlight: true),
+      );
+      final selected = EraPolygonGlowLayer.outerGlowAlphaFor(
+        entry: _entry(selected: true),
+      );
+      expect(picker, greaterThan(base));
+      expect(picker, lessThanOrEqualTo(selected + 0.05));
+
+      // fill 도 같은 방향 (center 기준).
+      final fillBase = EraPolygonGlowLayer.fillCenterAlphaFor(
+        entry: _entry(selected: false),
+      );
+      final fillPicker = EraPolygonGlowLayer.fillCenterAlphaFor(
+        entry: _entry(selected: false, pickerHighlight: true),
+      );
+      expect(fillPicker, greaterThan(fillBase));
+
+      // 선택된 폴리곤은 pickerHighlight 와 무관 (isSelected 가 우선).
+      expect(
+        EraPolygonGlowLayer.outerGlowAlphaFor(
+          entry: _entry(selected: true, pickerHighlight: true),
+        ),
+        EraPolygonGlowLayer.outerGlowAlphaFor(entry: _entry(selected: true)),
       );
     });
   });


### PR DESCRIPTION
## Summary

첫 화면(intro)·시트 헤더·지도 핀 등 흐름 전반의 UX 폴리시. 사용자 보고로 받은 11개 항목을 한 번에 정리.

### 시각/UX

- 시대 선택 후 1번 영역을 `AnimatedOpacity 0.55` 로 dim, 2번 헤더를 `ink800` + 굵은 글씨로 강조해 다음 행동을 자연스럽게 유도.
- 우측 stepper 라벨을 `1·2·3·?` → `홈·1·2·?` 로 변경. step 1 dot 은 `Icons.home_rounded` — "intro 화면 복귀" 가 직관적.
- 시트 헤더의 두 ▲▼ IconButton + 갈색 indicator bar 를 단일 **연한 초록 toggle pill** (▲↔▼) 로 통합. stepper 와 시각 충돌 해소 + 드래그 오해 해소.
- 시트가 화면 맨 아래(`bottom: 0`) 까지 차지하고 height 를 `sheetHeight + bottomInset` 으로 키워 panel 양피지가 nav bar 영역까지 자연스럽게 이어진다. 컨텐츠는 각 panel Column 의 `SizedBox(bottomInset)` 로 nav bar 위에 안전 배치 (gesture-only 단말은 bottomInset=0 → 기존 동작).
- 제목/하단 안내 문구를 `FittedBox.scaleDown` + `maxLines:1` 로 좁은 폰에서도 1줄 보장.
- 인물 모드 진입 시 `StoryMapPanel.suppressRegionLabels=true` 로 가나안·시내 광야·애굽 등 검정 캡슐 라벨을 숨김 — 인물 path 점선이 라벨에 가려지던 문제 해소.
- 사건 카드 인물 pill 정렬/색을 변경 — 사용자가 고른 인물을 가장 앞쪽 + 지도 path 색과 동일 톤으로 강조 (`StoryEventThumbCard.highlightedCharacterCodes` + `colorForHighlightedCharacter` 신규 prop).
- `StorySelectionPanel` 헤더를 sticky — 옛 \`Stack [CustomScrollView { headerOverride sliver, body slivers }, fade]\` 구조에서 \`Column [header, Expanded(Stack [CustomScrollView{body}, fade])]\` 로 분리해 사건 카드 스크롤 시 헤더(toggle + stepper) 가 함께 사라지지 않는다.
- **지도 사건 번호 핀** — 사건에 포함된 사용자 선택 인물의 색을 모아 `_MultiColorCirclePainter` 가 위→아래 균등 N 등분 띠로 핀 동그라미를 채움. 1명=단색, 2명=반반, N명=N등분. selected 핀은 그 위에 노란 outer border + 두꺼운 stroke + 사이즈 +2 로 "현재 이야기" 강조 유지.
- `MapHintOverlay` 신규 — 모드별 가운데 흐린 안내. \`_isUserGestureSource\` 로 식별한 사용자 제스처/region 선택/character 진행 한 번이면 dismiss. \`IgnorePointer\` 로 감싸 폴리곤·핀 클릭은 그대로 통과.
- `EraPolygonGlowLayer.pickerHighlight` 신규 — region picker 단계 후보 폴리곤의 outer glow / fill alpha 가 0.06~0.08 부스트. \`isSelected\` 가 항상 우선이라 선택 폴리곤이 더 또렷.

### 변경 파일 (10)

- \`lib/screens/story_home_screen.dart\` — intro/시트 헤더/stepper/safe area/hint overlay/region 라벨 토글
- \`lib/widgets/v2/home_intro_panel.dart\` — dim/highlight + FittedBox 1줄
- \`lib/widgets/v2/map_hint_overlay.dart\` — **신규**
- \`lib/widgets/story_map_panel.dart\` — suppressRegionLabels / onMapInteraction / 번호 핀 N 등분
- \`lib/widgets/story_selection_panel.dart\` — 헤더 sticky + 카드 인물 pill prop forwarding
- \`lib/widgets/event_timeline_row.dart\` — pill 색/정렬 prop forwarding
- \`lib/widgets/v2/region_event_list.dart\` — \`_CharPillAvatar.accentColor\` + \`_orderedCharacterCodes\`
- \`lib/widgets/map/era_polygon_glow_layer.dart\` — \`EraPolygonEntry.pickerHighlight\` + alpha 분기
- \`test/widgets/map/era_polygon_glow_layer_test.dart\` — pickerHighlight 동작 명세 케이스
- \`docs/FRONTEND.md\` — \`StoryHomeScreen\`/\`StoryMapPanel\`/\`StorySelectionPanel\`/\`HomeIntroPanel\`/\`MapHintOverlay\` 항목 동기화

## Test plan

- [x] \`flutter analyze\` — 0 issues
- [x] \`flutter test\` — 312 / 312 passed (era_polygon_glow_layer pickerHighlight 신규 케이스 포함)
- [x] pre-push hook — analyze + test + asset paths + polygon coverage + code metrics 모두 통과
- [x] 실기기 시연: 첫 진입 → 시대 선택 (1번 dim 확인) → 인물과 걷기 → 인물 2-3명 선택 후 「다음」 → 사건 핀이 인물 색 N등분으로 표시되는지, region 검정 캡슐 라벨이 사라졌는지, 카드 안 pill 색이 path 색과 매칭되는지
- [x] 실기기 시연: 장소에서 시작 → MapHintOverlay 가 가운데 떴다가 지도 탭/줌 시 사라지는지
- [x] 실기기 시연: 사건 카드를 위로 끝까지 스크롤해도 헤더(toggle + stepper) 가 그대로 남는지
- [x] 실기기 시연 (3-button nav bar 폰): panel 양피지가 nav bar 영역까지 이어지고 컨텐츠가 위에 안전하게 배치되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)