### PR TITLE
supabase/migrations/ 부활 + db-migrate make 타겟 (ADR-023)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ LANDMARKS_DIR := $(ASSETS_DIR)/landmarks
         generate-avatars generate-story-images generate-basemap thumbnails \
         seed-all generate-all \
         export-stories-json \
-        db-init apply-seeds apply-bible-verses-seeds apply-seeds-stories-characters \
+        db-init db-migrate apply-seeds apply-bible-verses-seeds apply-seeds-stories-characters \
         apply-seeds-landmarks apply-seeds-era-boundaries \
         upload-character-avatars upload-character-avatars-force \
         sync-approved-proposal-assets sync-approved-proposal-assets-all \
@@ -86,7 +86,8 @@ help:
 	@echo "  export-stories-json       [ENV=dev]  DB events → assets/200_stories/*.json 역추출 (빌더 사전 조건)"
 	@echo ""
 	@echo "DB 적용 (psql + .env의 SUPABASE_DB_URL_$(ENV)):"
-	@echo "  db-init                   [ENV=dev]  db_init.sql 실행 (drop & recreate, 파괴적!)"
+	@echo "  db-init                   [ENV=dev]  db_init.sql 실행 (drop & recreate, 파괴적!) → db-migrate 자동"
+	@echo "  db-migrate                [ENV=dev]  supabase/migrations/*.sql 알파벳 순 적용 (idempotent — prod 증분 적용용)"
 	@echo "  apply-bible-verses-seeds  [ENV=dev]  krv 성경 구절만 적용 (1회성, 중복 INSERT 시 에러)"
 	@echo "  apply-seeds-stories-characters       [ENV=dev]  characters + 200_stories 적용 (UPSERT — 재실행 안전)"
 	@echo "  apply-seeds               [ENV=dev]  위 둘 모두 (최초 부트스트랩용)"
@@ -349,6 +350,21 @@ db-init:
 	@$(PYTHON) $(TOOLS_DIR)/supabase/purge_owned_buckets.py --env $(ENV) || \
 	  echo "[Makefile] (Storage purge 스킵 — service_role 키 없거나 실패, db-init 은 계속)"
 	$(call PSQL_APPLY,db_init.sql)
+	@echo "[Makefile] db-init 후속: supabase/migrations/ 자동 적용"
+	@$(MAKE) db-migrate ENV=$(ENV)
+
+# supabase/migrations/*.sql 알파벳 순 적용. 모든 파일은 idempotent 하게 작성
+# (create or replace, if exists, on conflict, cron.unschedule + cron.schedule 등)
+# 되어 있어 여러 번 실행해도 안전. db-init 직후엔 db_init.sql 이 같은 내용을
+# 이미 만들어 둔 상태라 no-op 에 가깝다 (cron 재등록 정도).
+#
+# 신규 환경 부트스트랩: db-init 이 자동으로 호출 — 별도 명령 불필요.
+# 기존 prod 증분 적용: make db-migrate ENV=prod
+#
+# 정책: ADR-023, docs/BACKEND.md §8.
+db-migrate:
+	@echo "[Makefile] supabase/migrations/*.sql 적용 (ENV=$(ENV))"
+	$(call PSQL_APPLY,$(wildcard $(SUPABASE_DIR)/migrations/*.sql))
 
 # Bible verses 시드는 PK 충돌 시 에러 → 보통 1회만 실행 (db_init.sql 직후).
 apply-bible-verses-seeds:

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -452,3 +452,30 @@
   - bell drop 은 "새 이야기" 같은 영구 기록성 알림만 받음.
   - service_role_key 가 SQL 함수 본문에 박히지 않아 코드 리뷰 시 노출 방지.
 - **보충 (매일 퀴즈 자동 초기화)**: `dispatch_daily_quiz_push` 는 단순히 푸시만 발송하지 않고 매 호출마다 daily_quiz 풀에서 random 1건을 pick 해 같은 content 로 **새 row 를 INSERT** 한다. 이렇게 하면 새 daily_quiz_id 가 발급되고, `user_daily_quiz_attempts` (PK: user_id, daily_quiz_id) 가 자연스럽게 다음 날 row 와 분리되어 사용자는 "어제 푼 결과가 사라진" 상태로 매일 새로 풀 수 있다. 주간 퀴즈는 `weekly_quiz_progress` 의 week_key 가 매주 자동으로 달라져서 별도 처리 불필요.
+
+## ADR-023: supabase/migrations/ 부활 + db-migrate 타겟 (2026-05-12)
+
+- **배경**: ADR-022 가 `dispatch_daily_quiz_push` 함수 + pg_cron 4개 스케줄을 `db_init.sql` 에 추가했으나, 그 변경분을 prod DB 에 별도로 적용하지 않아 매일 KST 9시의 자동 새 quiz 발급이 누락됐다. 사용자는 "어제 답한 quiz/답안이 그대로" 라고 보고했고, 진단 결과 `cron.job` 테이블에 4개 cron 이 모두 미등록 상태였다 (수동 SQL 실행 후 복구). 같은 형태의 사고 — `db_init.sql` 에는 들어갔으나 prod 적용 누락 — 가 이 PR 이전에도 잠재적으로 있었을 가능성이 있고, 향후 DB 변경 시마다 반복될 위험.
+- **결정**: 옛 정책 ("`supabase/migrations/` 디렉토리 폐기, `db_init.sql` 만 단일 진실 소스") 을 뒤집어 **두 트랙을 동시에** 운영한다.
+  1. **`db_init.sql`** — 여전히 단일 진실 소스. 신규 환경 부트스트랩 (DROP & CREATE) 용.
+  2. **`supabase/migrations/<YYYYMMDD>_<HHMM>_<slug>.sql`** — 직전 prod 상태 → 현재 desired 상태로 가는 증분 패치. 모두 idempotent (`create or replace`, `if exists`, `cron.unschedule + cron.schedule` 등) 패턴 강제.
+  3. **`make db-migrate`** 신규 타겟 — `supabase/migrations/*.sql` 알파벳 순 적용. `make db-init` 끝에 자동 호출되어 신규 환경에서도 동일 적용 (idempotent 라 no-op). prod 증분 적용은 `make db-migrate ENV=prod`.
+  4. **PR 워크플로 강화**: schema/function/cron 등 DB 변경 PR 은 항상 두 곳을 동시 수정 (db_init.sql + supabase/migrations/). reviewer 가 두 파일이 같은 변경을 표현하는지 확인.
+- **이유**:
+  1. db_init.sql 이 완벽하게 prod 의 desired state 를 표현해도, prod 에 그 SQL 을 누군가 실행하지 않으면 무의미. `make db-init ENV=prod` 는 파괴적이라 사실상 못 돌리고, 결국 운영자가 SQL Editor 에 발췌해 수동 실행 — 누락 위험이 누적된다.
+  2. 증분 마이그레이션 트랙이 있으면 prod 적용이 한 명령 (`make db-migrate ENV=prod`) 으로 통일되고, idempotent 파일이라 머지 후 언제 돌려도 안전.
+  3. 신규 환경 부트스트랩은 `db_init.sql` 한 번이면 충분하므로 두 트랙이 redundant 해 보이지만, 두 곳 동기화 비용은 한 PR 당 SQL 한 블록 복사 정도로 작은 반면 prod 누락 사고를 원천 차단할 수 있음.
+- **사용자 워크플로 변경**: 없음. 신규 환경 부트스트랩 시퀀스 — `make seed-all && make db-init && make apply-seeds && make upload-character-avatars` — 는 그대로 유지. `make db-init` 안에서 `make db-migrate` 가 자동 호출되어 마이그레이션 파일도 함께 적용된다 (idempotent 라 no-op). 신규 워크플로는 "prod 증분 적용 = `make db-migrate ENV=prod`" 한 줄만 추가.
+- **DB/파일 변경**:
+  - 신규 디렉토리: `supabase/migrations/`
+  - 첫 마이그레이션 파일: `20260512_1144_pg_cron_dispatch_and_schedules.sql` — ADR-022 의 dispatch_daily_quiz_push 함수 + pg_cron 4개 스케줄 등록 (idempotent). prod 에는 이미 수동 적용됐지만 신규 환경 / 다른 prod (향후) / 정책 reference 로 명문화.
+  - `Makefile`: `db-migrate` 타겟 추가, `db-init` 끝에 `make db-migrate` 자동 호출 추가, `.PHONY`/help 갱신.
+  - `docs/BACKEND.md §8` 전면 개정 (위 정책 반영).
+- **결과**:
+  - 향후 DB 변경은 PR 단계에서 두 파일이 함께 들어와야 하므로 reviewer 가 prod 적용 누락을 사전에 catch.
+  - prod 운영자는 `make db-migrate ENV=prod` 한 줄로 모든 idempotent 변경분 일괄 적용 가능.
+  - dev 환경은 기존 `make db-init` 워크플로 그대로 — 마이그레이션은 bonus 로 자동 적용.
+- **남은 옵션 (향후)**:
+  - 마이그레이션 적용 이력 추적 테이블 (`_schema_migrations`) 도입해 같은 파일 중복 실행 방지 — 현재는 idempotent 패턴으로 안전하지만, 마이그레이션 수가 누적되면 매번 모두 실행은 비효율.
+  - GitHub Actions 로 main 머지 시 dev `make db-migrate` 자동 실행 — prod 자동 적용은 위험하니 수동 trigger 유지.
+  - Supabase CLI 의 정식 마이그레이션 (`supabase db push`) 으로 전환 — `supabase_migrations.schema_migrations` 자동 추적 + Studio 통합. 다만 본 프로젝트는 db_init.sql 을 신규 환경 부트스트랩 용도로 유지하고 싶어 두 트랙 병행 (CLI 는 마이그레이션만 추적).

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -562,16 +562,80 @@ supabase functions serve \
 
 브라우저/Flutter 에서 호출 시 base URL 을 로컬 것으로 바꿔 테스트.
 
-## 8. 마이그레이션 관리 규칙
+## 8. 마이그레이션 관리 규칙 (ADR-023, 2026-05-12 개정)
 
-1. `db_init.sql`이 스키마의 **단일 진실 소스** (Single Source of Truth — 단일 파일에서
-   DROP & CREATE 전체).
-2. 스키마 변경 시: `db_init.sql` 만 수정. 별도 증분 마이그레이션 파일은 만들지
-   않는다 (`supabase/migrations/` 디렉토리 폐기).
-3. 로컬/원격 초기화 동일하게: `make db-init` → DROP + CREATE 전체 재실행.
-4. 운영 반영: SQL Editor 또는 `make db-init` (대상 환경 ENV 지정).
-5. 이전에 폐기된 증분 마이그레이션의 의도/맥락은 [ADR.md](ADR.md) 와
-   [guides/WORKFLOW_GUIDE.md](guides/WORKFLOW_GUIDE.md) 의 역사 섹션에 보존.
+> ⚠️ **정책 변경**: ADR-022 의 `daily_quiz` cron 이 prod 에 누락된 사고를 계기로
+> 옛 "supabase/migrations/ 폐기" 정책을 뒤집었다. 이제 **`db_init.sql` + `supabase/migrations/`
+> 두 곳을 동기화** 한다.
+
+### 8.1 두 트랙의 역할
+
+| 트랙 | 역할 | 적용 환경 | 적용 명령 |
+|------|------|----------|----------|
+| `db_init.sql` | 스키마 **단일 진실 소스** (전체 DROP & CREATE 한 파일에 응축) | **신규 환경 부트스트랩** | `make db-init ENV=<env>` (파괴적!) |
+| `supabase/migrations/<ts>_<slug>.sql` | 직전 prod 상태 → 현재 desired 상태로 가는 **증분 패치** | **기존 prod 증분 적용** | `make db-migrate ENV=prod` |
+
+`make db-init` 은 db_init.sql 적용 직후 자동으로 `make db-migrate` 까지 실행하므로,
+신규 환경 부트스트랩 시퀀스는 변경되지 않는다:
+
+```bash
+make seed-all && make db-init && make apply-seeds && make upload-character-avatars
+#                  └─ db_init.sql + db-migrate 자동 (idempotent)
+```
+
+기존 prod 에 새 변경분만 안전하게 반영하려면:
+
+```bash
+make db-migrate ENV=prod
+```
+
+### 8.2 변경 시 작업 흐름
+
+스키마/함수/RLS/cron/extension 등 DB 가 변경될 때마다 다음 두 곳을 **항상 동시에** 수정한다:
+
+1. **`db_init.sql`** — 변경 후 최종 상태로 갱신 (DROP & CREATE 한 파일에 응축).
+2. **`supabase/migrations/YYYYMMDD_HHMM_<slug>.sql`** — 변경분만 담은 증분 파일.
+   - 파일명: 적용 시점 timestamp (KST 기준 권장) + 짧은 의도 slug.
+   - 모든 SQL 은 **idempotent** 하게 작성 (재실행 안전):
+     - 함수: `create or replace function ...`
+     - 테이블/컬럼: `if not exists`, `add column if not exists`
+     - 인덱스/policy: `drop ... if exists` → `create ...`
+     - cron: `cron.unschedule(jobname) where ... ; cron.schedule(...)`
+     - 시드: `on conflict do nothing` 또는 `do update`
+   - 파일 첫 주석에 의도 + ADR 참조 + idempotent 보장 근거 명시.
+
+PR 머지 전 reviewer 는 두 파일이 같은 변경을 표현하는지 확인.
+
+### 8.3 prod 적용 절차
+
+PR 머지 직후 (또는 hot fix 시점에):
+
+```bash
+# 1. main 최신 상태로 update
+git checkout main && git pull
+
+# 2. prod 적용 — supabase/migrations/*.sql 을 알파벳 순으로 모두 실행 (idempotent 라 안전)
+make db-migrate ENV=prod
+
+# 3. 검증 (예: 새 cron 등록됐는지)
+psql "$SUPABASE_DB_URL_PROD" -c "select jobname, active from cron.job order by jobname;"
+```
+
+### 8.4 이력 보존
+
+- `supabase/migrations/` 가 시간순 변경 이력 (각 파일이 한 PR 의 desired delta).
+- 옛 ADR (ADR-009 이전의 폐기된 증분 마이그레이션) 의 의도/맥락은
+  [ADR.md](ADR.md) 와 [guides/WORKFLOW_GUIDE.md](guides/WORKFLOW_GUIDE.md) 에서 역사로 참조.
+
+### 8.5 자주 빠트리는 것
+
+- **새 함수가 `cron.schedule` 에 등록될 때**: 그 함수 정의도 마이그레이션에 포함해야
+  prod 에 함수가 없어도 안전. 의존 함수가 이미 prod 에 있다고 확신할 수 없으면
+  마이그레이션에 함께 포함하거나, 별도 선행 마이그레이션을 먼저 만든다.
+- **`pg_cron` 같은 extension 의존**: 마이그레이션이 `if exists pg_extension where extname='pg_cron'`
+  가드를 두지 않으면 미설치 환경에서 실패한다. 가드 + `raise warning` 으로 명시적 skip 알림.
+- **데이터 변경 (UPDATE/DELETE/INSERT)** 은 마이그레이션 파일에 넣지 말고 `apply-seeds`
+  계열로 별도 분리 — 마이그레이션은 schema·function·trigger·cron·policy 등 *구조* 만 다룬다.
 
 ## 9. Supabase 공식 Agent Skills
 

--- a/supabase/migrations/20260512_1144_pg_cron_dispatch_and_schedules.sql
+++ b/supabase/migrations/20260512_1144_pg_cron_dispatch_and_schedules.sql
@@ -1,0 +1,133 @@
+-- 20260512_1144_pg_cron_dispatch_and_schedules.sql
+--
+-- 매일 퀴즈 자동 발급 함수 + pg_cron 4개 스케줄 등록.
+--
+-- 배경 (ADR-022, ADR-023):
+--   ADR-022 에서 dispatch_daily_quiz_push() 함수 + pg_cron 스케줄을
+--   db_init.sql 에 추가했으나, 옛 정책상 prod 에 자동 반영되지 않아 KST 9시
+--   매일 새 quiz row 발급이 누락됐다. 사용자가 어제 답한 quiz/답안이 그대로
+--   유지되어 "오늘의 퀴즈가 갱신되지 않는다" 사고 발생.
+--
+--   ADR-023 에서 supabase/migrations/ 부활 — 모든 schema/function/cron 변경은
+--   db_init.sql 과 supabase/migrations/<timestamp>_<slug>.sql 두 곳에 동시 작성.
+--   `make db-init` 은 신규 환경 부트스트랩 (db_init.sql 전체 + 그 직후 자동
+--   db-migrate), `make db-migrate ENV=prod` 는 기존 prod 의 증분 적용.
+--
+-- 동작:
+--   - daily-quiz-9am-kst (매일 KST 9시 = UTC 0시):
+--       daily_quiz 풀에서 random 1건 → 같은 내용으로 새 row INSERT (새 PK)
+--       → fetchLatestDailyQuiz 가 새 row 반환, user_daily_quiz_attempts 자동 분리
+--       → 클라이언트 입장에서 "오늘 퀴즈 초기화 + 답안 입력 가능" + push 발송
+--   - weekly-character-monday (월 KST 9시): 금주 인물 선정
+--   - weekly-progress-wed/fri (수·금 KST 9시): 주중·주말 진도 알림
+--
+-- Idempotent — 여러 번 실행해도 동일 결과:
+--   * create or replace function — 함수는 항상 최신
+--   * if exists pg_extension — pg_cron 미설치면 cron.schedule 통째 skip
+--   * cron.unschedule + cron.schedule — 같은 jobname 재등록 안전
+--
+-- 의존:
+--   - public.daily_quiz, public._fire_push_broadcast(text,text,text,text)
+--   - public.pick_weekly_character(), public.notify_weekly_progress()
+--   모두 db_init.sql 에 정의되어 있어야 함.
+
+-- ─── 함수 ────────────────────────────────────────────────────────────────
+-- db_init.sql §"매일 퀴즈 푸시" 와 동일.
+
+create or replace function public.dispatch_daily_quiz_push()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_picked record;
+  v_new_id uuid;
+  v_body text;
+begin
+  -- 풀에서 random 1건 pick. cron 이 만든 옛 row 와 시드 row 가 섞여 있어도
+  -- 모두 동일하게 풀로 취급 — 단순함 우선.
+  select question, choice_1, choice_2, choice_3, choice_4, answer_index, explanation
+    into v_picked
+    from daily_quiz
+    order by random()
+    limit 1;
+
+  if v_picked.question is null then
+    raise warning '[dispatch_daily_quiz_push] daily_quiz pool is empty — skipped';
+    return;
+  end if;
+
+  -- 같은 content 로 새 row INSERT (created_at 자동 = now()). 새 PK 발급으로
+  -- 클라이언트의 fetchLatestDailyQuiz 가 이 새 row 를 가져오게 되고
+  -- user_daily_quiz_attempts 매핑도 자동 분리된다.
+  insert into daily_quiz (
+    question, choice_1, choice_2, choice_3, choice_4, answer_index, explanation
+  )
+  values (
+    v_picked.question, v_picked.choice_1, v_picked.choice_2,
+    v_picked.choice_3, v_picked.choice_4, v_picked.answer_index, v_picked.explanation
+  )
+  returning id into v_new_id;
+
+  -- 푸시 본문 길이 제한(iOS ~178자) 고려해 길면 자른다.
+  if length(v_picked.question) > 110 then
+    v_body := substr(v_picked.question, 1, 107) || '...';
+  else
+    v_body := v_picked.question;
+  end if;
+
+  -- deep_link='/weekly' — 매일 퀴즈는 QuizTabPage 안의 한 섹션이라 weekly 화면을
+  -- 그대로 연다. 클라이언트의 NotificationDeepLink.parse 는 weekly 만 인식.
+  perform public._fire_push_broadcast(
+    '오늘의 퀴즈가 도착했어요',
+    v_body,
+    '/weekly',
+    'daily_quiz'
+  );
+end;
+$$;
+grant execute on function public.dispatch_daily_quiz_push() to authenticated;
+
+-- ─── pg_cron 스케줄 ──────────────────────────────────────────────────────
+-- 모든 시간은 KST 9시 = UTC 0시 기준.
+-- pg_cron 미활성화면 통째 skip — Supabase Dashboard → Database → Extensions
+-- → pg_cron Enable 후 이 마이그레이션을 다시 적용해야 한다.
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    perform cron.unschedule(jobname)
+    from cron.job
+    where jobname in (
+      'daily-quiz-9am-kst',
+      'weekly-character-monday',
+      'weekly-progress-wed',
+      'weekly-progress-fri'
+    );
+
+    perform cron.schedule(
+      'daily-quiz-9am-kst',
+      '0 0 * * *',
+      $cmd$ select public.dispatch_daily_quiz_push(); $cmd$
+    );
+    perform cron.schedule(
+      'weekly-character-monday',
+      '0 0 * * 1',
+      $cmd$ select public.pick_weekly_character(); $cmd$
+    );
+    perform cron.schedule(
+      'weekly-progress-wed',
+      '0 0 * * 3',
+      $cmd$ select public.notify_weekly_progress(); $cmd$
+    );
+    perform cron.schedule(
+      'weekly-progress-fri',
+      '0 0 * * 5',
+      $cmd$ select public.notify_weekly_progress(); $cmd$
+    );
+  else
+    raise warning '[migration] pg_cron not installed — cron schedules skipped. '
+                  'Enable pg_cron in Supabase Dashboard then re-apply this migration.';
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

ADR-022 의 `dispatch_daily_quiz_push` 함수 + pg_cron 4개 스케줄이 `db_init.sql` 에는 추가됐으나 prod 에 별도 적용되지 않아 매일 KST 9시의 daily_quiz 자동 발급이 누락되는 사고 발생. 옛 \"supabase/migrations/ 폐기\" 정책을 뒤집어 두 트랙 (`db_init.sql` + `supabase/migrations/`) 동시 운영 정책으로 전환.

### 두 트랙 정책

| 트랙 | 역할 | 적용 환경 | 명령 |
|------|------|----------|------|
| \`db_init.sql\` | 단일 진실 소스 (DROP & CREATE 한 파일) | 신규 환경 부트스트랩 | \`make db-init ENV=<env>\` |
| \`supabase/migrations/<ts>_<slug>.sql\` | 직전 상태 → 현재 desired 증분 패치 | 기존 prod 증분 적용 | \`make db-migrate ENV=prod\` |

### 사용자 워크플로

**변경 없음** — 기존 부트스트랩 그대로:
\`\`\`bash
make seed-all && make db-init && make apply-seeds && make upload-character-avatars
#                  └─ db_init.sql + db-migrate 자동 (idempotent no-op)
\`\`\`

**추가 (prod 증분)**:
\`\`\`bash
make db-migrate ENV=prod
\`\`\`

### 변경 파일 (4)

- **\`supabase/migrations/20260512_1144_pg_cron_dispatch_and_schedules.sql\`** — 신규. ADR-022 의 dispatch_daily_quiz_push 함수 + pg_cron 4개 스케줄. 모두 idempotent (\`create or replace\`, \`cron.unschedule + schedule\`, \`if exists pg_extension\` 가드).
- **\`Makefile\`** — \`db-migrate\` 타겟 신규 (\`\$(wildcard supabase/migrations/*.sql)\` 알파벳 순 적용). \`db-init\` 끝에 \`make db-migrate\` 자동 호출 추가. \`.PHONY\`/help 갱신.
- **\`docs/BACKEND.md §8\`** — 정책 전면 개정. 두 트랙 역할 표 / 변경 시 두 곳 동기화 강제 / prod 적용 절차 / 자주 빠트리는 항목 (extension 의존, 함수 의존, 데이터 변경 분리).
- **\`docs/ADR.md ADR-023\`** — 신규 ADR. 옛 정책 (ADR-009 이전) 뒤집은 사유 (ADR-022 cron 누락 사고), 결정, 향후 옵션 (이력 추적 테이블 / GH Actions / supabase CLI).

### Idempotent 보장 (마이그레이션 파일 작성 규칙)

PR reviewer 가 \`supabase/migrations/\` 의 새 파일을 볼 때 다음 패턴이 모두 적용됐는지 확인:
- 함수: \`create or replace function\`
- 테이블/컬럼: \`if not exists\`, \`add column if not exists\`
- 인덱스/policy: \`drop ... if exists\` → \`create ...\`
- cron: \`cron.unschedule(jobname) where ... ; cron.schedule(...)\`
- 시드: \`on conflict do nothing\` 또는 \`do update\`
- extension 의존 시 \`if exists pg_extension where extname='...'\` 가드 + \`raise warning\` skip 알림

### 첫 마이그레이션 파일은 prod 에 이미 수동 적용된 상태

이번 디버깅 과정에서 사용자가 SQL Editor 에서 \`dispatch_daily_quiz_push\` 함수와 pg_cron 4개 스케줄을 이미 적용 완료. 첫 마이그레이션 파일은 idempotent 라 다음 prod \`make db-migrate ENV=prod\` 시 no-op. 신규 환경 / reference / 정책 명문화 용도.

## Test plan

- [x] \`make help\` 에 \`db-init\` (db-migrate 자동 메모) + \`db-migrate\` 두 줄 정상 출력
- [x] pre-commit hook (yaml/format/forbidden patterns/import sort) 통과
- [x] pre-push hook (analyze + test + asset paths + polygon coverage + code metrics) 통과
- [ ] **dev 환경에서 \`make db-init ENV=dev\` 한 번 실행해 db_init.sql + db-migrate 가 자동 연결되어 동작하는지 검증** (DROP & RECREATE 라 dev 데이터 날아감 — 의도적 시나리오 한정)
- [ ] **prod 에 \`make db-migrate ENV=prod\` 실행해 idempotent 동작 (이번 마이그레이션은 no-op) 확인**
- [ ] 다음 DB 변경 PR 작성 시 두 곳 (db_init.sql + supabase/migrations/) 동기화가 실제로 잘 지켜지는지 모니터링

## Reviewer 체크리스트

- [ ] 마이그레이션 파일 첫 주석에 의도 + ADR 참조 + idempotent 근거가 명시됐는가
- [ ] \`make db-init\` 끝의 \`make db-migrate\` 자동 호출이 신규 환경 시퀀스를 깨지 않는가 (no-op 보장)
- [ ] BACKEND.md §8 의 두 트랙 정책이 향후 PR 작성자에게 충분히 명확한가
- [ ] ADR-023 의 \"향후 옵션\" 중 즉시 채택할 항목이 있는가 (예: GH Actions main 머지 시 dev auto-migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)